### PR TITLE
feat: add method: get signed upload url

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,8 +1,8 @@
 {
-  "trailingComma": "all",
-  "semi": true,
-  "singleQuote": true,
-  "bracketSpacing":true,
-  "arrowParens":"avoid",
-  "useTabs":true
+	"trailingComma": "all",
+	"semi": true,
+	"singleQuote": true,
+	"bracketSpacing": true,
+	"arrowParens": "avoid",
+	"useTabs": true
 }

--- a/README.md
+++ b/README.md
@@ -12,26 +12,23 @@
 
 </p>
 
-
 <p align="center">
 <a href="https://www.buymeacoffee.com/XbgWxt567" target="_blank"><img src="https://i.imgur.com/CahshSS.png" alt="Buy Me A Coffee" style="height: auto !important;width: auto !important;" ></a>
 
 </p>
 
-
 ## Description
+
 This's a [nest-cloudinary](https://github.com/rubiin/nest-cloudinary) module for [Nest](https://github.com/nestjs/nest).
 This quickstart guide will show you how to install the client SDK and execute an example JavaScript program. For a complete list of APIs and examples, please take a look at the [JavaScript Client API Reference](https://docs.min.io/docs/javascript-client-api-reference) documentation.
 
 This document assumes that you have a working [nodejs](http://nodejs.org/) setup in place.
-
 
 ## Installation
 
 ```bash
 $ npm i --save nestjs-cloudinary
 ```
-
 
 ## Initialize cloudinary Client
 
@@ -42,51 +39,46 @@ import { Module } from '@nestjs/common';
 import { CloudinaryModule } from 'nestjs-cloudinary';
 
 @Module({
-  imports: [
+	imports: [
 		CloudinaryModule.forRootAsync({
 			imports: [NestConfigModule],
 			useFactory: (configService: ConfigService) => ({
 				isGlobal: true,
-				cloud_name: configService.get("cloudinary.cloudName"),
-				api_key: configService.get("cloudinary.apiKey"),
-				api_secret: configService.get("cloudinary.apiSecret")
+				cloud_name: configService.get('cloudinary.cloudName'),
+				api_key: configService.get('cloudinary.apiKey'),
+				api_secret: configService.get('cloudinary.apiSecret'),
 			}),
 			inject: [ConfigService],
 		}),
 	],
 })
 export class NestCloudinaryClientModule {}
-
 ```
+
 Then you can use it in the controller or service by injecting it in the controller as:
 
-```javascript
+```typescript
 import { CloudinaryService } from 'nestjs-cloudinary';
 
- constructor(private readonly cloudinaryService: CloudinaryService ) {}
+constructor(private readonly cloudinaryService: CloudinaryService ) {}
 
 ```
 
 ## Quick Start Example - File Uploader
+
 This example program connects to cloudinary storage server then uploads a file.
 
-
-```js
-
+```typescript
 import { Controller, Get, Inject } from '@nestjs/common';
 import { CloudinaryService } from 'nestjs-cloudinary';
 
 @Controller()
 export class NestCloudinaryClientController {
-
-constructor(private readonly cloudinaryService: CloudinaryService ) {}
-@Post('upload')
-@UseInterceptors(FileInterceptor('file'))
-uploadFile(@UploadedFile() file: Express.Multer.File) {
-  return this.cloudinaryService.upload(file);
+	constructor(private readonly cloudinaryService: CloudinaryService) {}
+	@Post('upload')
+	@UseInterceptors(FileInterceptor('file'))
+	async uploadFile(@UploadedFile() file: Express.Multer.File) {
+		return this.cloudinaryService.upload(file);
+	}
 }
-
-}
-
-
 ```

--- a/src/cloudinary.constant.ts
+++ b/src/cloudinary.constant.ts
@@ -1,0 +1,7 @@
+import { ISignedUploadUrlOptions } from './interfaces';
+
+export const defaultCreateSignedUploadUrlOptions: Partial<ISignedUploadUrlOptions> =
+	{
+		folder: undefined,
+		eager: undefined,
+	};

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -1,2 +1,3 @@
 export * from './file.interface';
 export * from './sharp.interface';
+export * from './signed-upload-url.interface';

--- a/src/interfaces/signed-upload-url.interface.ts
+++ b/src/interfaces/signed-upload-url.interface.ts
@@ -1,0 +1,4 @@
+export interface ISignedUploadUrlOptions {
+	folder?: string;
+	eager?: string;
+}


### PR DESCRIPTION
Hi,
I am glad that this project(nestjs + cloudinary) is started! :) 
I usually use signed upload URL method, instead of direct upload method. So I added the method.
Please check it out. Thanks


Further explanation about the PR:
Using `createSignedUploadUrl` method, we can get signed URL. Then we can upload file to the URL directly without bypassing nestjs server.
```ts
const result = this.cloudinaryService.createSignedUploadUrl('hello.png', 'image', { folder: 'my-images' });
//  result includes url(which is signed upload url), publicId, apiKey, timestamp, signature, other options...)
```

```ts
// browser
const formData = new FormData();
formData.append('file', someFile);
axios.post(signedUrl, formData, {
	params: {
		timestamp,
		signature,
		publicId,
		apiKey,
		eager,
		folder,
	},
});
```
